### PR TITLE
Add max-age Cache-Control setting

### DIFF
--- a/config/vidStreamer-sample.json
+++ b/config/vidStreamer-sample.json
@@ -4,5 +4,6 @@
 	"random": false,
 	"rootFolder": "/path/to/videos/",
 	"rootPath": "videos/",
-	"server": "VidStreamer.js/0.1.4"
+	"server": "VidStreamer.js/0.1.4",
+	"maxAge": "3600"
 }

--- a/index.js
+++ b/index.js
@@ -227,7 +227,7 @@ var downloadHeader = function (res, info) {
 		};
 	} else {
 		header = {
-			"Cache-Control": "public",
+			"Cache-Control": "public; max-age=" + settings.maxAge,
 			Connection: "keep-alive",
 			"Content-Type": info.mime,
 			"Content-Disposition": "inline; filename=" + info.file + ";"


### PR DESCRIPTION
Some browsers might not cache the video files if "max-age" or "Expires" isn't set. This should fix that.
