### PR TITLE
Always provide Accept-Ranges header

### DIFF
--- a/index.js
+++ b/index.js
@@ -230,14 +230,14 @@ var downloadHeader = function (res, info) {
 			"Cache-Control": "public; max-age=" + settings.maxAge,
 			Connection: "keep-alive",
 			"Content-Type": info.mime,
-			"Content-Disposition": "inline; filename=" + info.file + ";"
+			"Content-Disposition": "inline; filename=" + info.file + ";",
+			"Accept-Ranges": "bytes"
 		};
 
 		if (info.rangeRequest) {
 			// Partial http response
 			code = 206;
 			header.Status = "206 Partial Content";
-			header["Accept-Ranges"] = "bytes";
 			header["Content-Range"] = "bytes " + info.start + "-" + info.end + "/" + info.size;
 		}
 	}


### PR DESCRIPTION
This change makes the server provide the Accept-Ranges header for every video request, not just the ones that specify a desired range. Internet Explorer 11 (and perhaps 10?) does not attempt to request a range unless it gets this header to an initial request without a range, so pseudo-streaming to IE11 does not work without this change.
