### PR TITLE
feature/no-throttle-head

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,7 +158,7 @@ var vidStreamer = function (req, res) {
 	}
 	stream = fs.createReadStream(info.path, { flags: "r", start: info.start, end: info.end });
 
-	if (settings.throttle) {
+	if (settings.throttle && req.method.toLowerCase() === 'get') {
 		stream = stream.pipe(new Throttle(settings.throttle))
 	}
 


### PR DESCRIPTION
turn throttling off for HEAD requests as we aren't serving the file but only creating a stream to determine the content-length for the header
