### PR TITLE
Allow to not insert content-disposition

### DIFF
--- a/index.js
+++ b/index.js
@@ -231,9 +231,13 @@ var downloadHeader = function (res, info) {
 			"Cache-Control": "public; max-age=" + settings.maxAge,
 			Connection: "keep-alive",
 			"Content-Type": info.mime,
-			"Content-Disposition": "inline; filename=" + info.file + ";",
 			"Accept-Ranges": "bytes"
 		};
+		
+		if (settings.insertContentDisposition == undefined || settings.insertContentDisposition){
+			header["Content-Disposition"] = "inline; filename=" + info.file + ";"
+		}
+		    
 
 		if (info.rangeRequest) {
 			// Partial http response


### PR DESCRIPTION
Some files with special encoding are not able to stream.
```bash
TypeError: The header content contains invalid characters
```

This setting: 
```json
{
  insertContentDisposition : false
}
```
desactive the header Content-Disposition and then the Express http requests do not fail because of header encoding errors.